### PR TITLE
Fix querystrings

### DIFF
--- a/files/general/etc/nginx/nginx.conf
+++ b/files/general/etc/nginx/nginx.conf
@@ -33,7 +33,7 @@ http {
         index index.php index.html;
 
         location / {
-            try_files $uri $uri/ /index.php;
+            try_files $uri $uri/ /index.php$is_args$args;
         }
 
         location ~ \.php$ {


### PR DESCRIPTION
Nginx wasn't passing along the args, not very handy if you are building an application that kind of needs them ;-)