### PR TITLE
Trust the X-Forwarded-For header for private subnets

### DIFF
--- a/files/general/etc/nginx/nginx.conf
+++ b/files/general/etc/nginx/nginx.conf
@@ -27,6 +27,11 @@ http {
     access_log /dev/stdout main;
     error_log /dev/stdout warn;
 
+    real_ip_header X-Forwarded-For;
+    set_real_ip_from 10.0.0.0/16;
+    set_real_ip_from 172.16.0.0/12;
+    set_real_ip_from 192.168.0.0/16;
+
     server {
         listen 80 default_server;
         root /www/public;


### PR DESCRIPTION
Currently, the logs of Docker contain the Ingress node's private IP instead of the visitor's IP.
I see we're getting an `X-Forwarded-For` and an `X-Real-Ip` (which differs from the expected `X-Real-IP`) passed trough to the container. 

This PR ensures the `X-Forwarded-For` header is trusted as real IP when the request originated from a private subnet (Class A, B or C).