### PR TITLE
Always pull the FROM images when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .PHONY: install build run stop clean test
 
 build:
-	docker build -t existenz/webstack:5.6 -f Dockerfile-5.6 .
-	docker build -t existenz/webstack:7.0 -f Dockerfile-7.0 .
-	docker build -t existenz/webstack:7.1 -f Dockerfile-7.1 .
+	docker build -t existenz/webstack:5.6 -f Dockerfile-5.6 --pull .
+	docker build -t existenz/webstack:7.0 -f Dockerfile-7.0 --pull .
+	docker build -t existenz/webstack:7.1 -f Dockerfile-7.1 --pull .
 
 install:
 	rm -rf files/s6-overlay


### PR DESCRIPTION
Hi ya, 

When building the stack locally, docker could potentially use your local alpine image instead of pulling a freshly updated one from the docker hub. By adding `--pull` to the make build target, we assure that we're always using the most recent alpine image.

Let me know what you think! :+1: 

