### PR TITLE
Configure Travis Matrix run and add PHP CLI to the image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,12 @@ matrix:
 services:
   - docker
 
-install:
-  - make install
+cache:
+  directories:
+    - files/s6-overlay
 
 script:
-  - make TAGNAME=$(printenv PHP_VERSION)
+  - make build TAGNAME=$(printenv PHP_VERSION)
   - make run TAGNAME=$(printenv PHP_VERSION)
   - sleep 15 # Wait for the docker health check to complete
   - make test TAGNAME=$(printenv PHP_VERSION)

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
   - make TAGNAME=$(printenv PHP_VERSION)
   - make run TAGNAME=$(printenv PHP_VERSION)
   - sleep 15 # Wait for the docker health check to complete
-  - make test
+  - make test TAGNAME=$(printenv PHP_VERSION)
 
 after_success:
   - if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+matrix:
+  include:
+    - env: PHP_VERSION=5.6
+    - env: PHP_VERSION=7.0
+    - env: PHP_VERSION=7.1
+
 services:
   - docker
 
@@ -5,8 +11,8 @@ install:
   - make install
 
 script:
-  - make
-  - make run
+  - make TAGNAME=$(printenv PHP_VERSION)
+  - make run TAGNAME=$(printenv PHP_VERSION)
   - sleep 15 # Wait for the docker health check to complete
   - make test
 

--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -2,9 +2,11 @@ FROM alpine:3.5
 
 MAINTAINER docker@stefan-van-essen.nl
 
-RUN apk -U upgrade && apk add \
+RUN apk -U upgrade && apk add --no-cache \
     curl \
+    libc6-compat \
     nginx \
+    php5-cli \
     php5-fpm \
     tzdata \
     && addgroup -S php \

--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -4,9 +4,7 @@ MAINTAINER docker@stefan-van-essen.nl
 
 RUN apk -U upgrade && apk add --no-cache \
     curl \
-    libc6-compat \
     nginx \
-    php5-cli \
     php5-fpm \
     tzdata \
     && addgroup -S php \

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -2,9 +2,11 @@ FROM alpine:3.5
 
 MAINTAINER docker@stefan-van-essen.nl
 
-RUN apk -U upgrade && apk add \
+RUN apk -U upgrade && apk add --no-cache \
     curl \
+    libc6-compat \
     nginx \
+    php7-cli \
     php7-fpm \
     tzdata \
     && addgroup -S php \

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -7,7 +7,7 @@ RUN apk -U upgrade && apk add --no-cache \
     nginx \
     php7-fpm \
     tzdata \
-    && ln -s /usr/bin/php-fpm7 /usr/bin/php-fpm \
+    && ln -s /usr/sbin/php-fpm7 /usr/sbin/php-fpm \
     && addgroup -S php \
     && adduser -S -G php php \
     && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/php7/conf.d/* /etc/php7/php-fpm.d/*

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -4,12 +4,10 @@ MAINTAINER docker@stefan-van-essen.nl
 
 RUN apk -U upgrade && apk add --no-cache \
     curl \
-    libc6-compat \
     nginx \
-    php7 \
     php7-fpm \
     tzdata \
-    && ln -s /usr/bin/php7 /usr/bin/php \
+    && ln -s /usr/bin/php-fpm7 /usr/bin/php-fpm \
     && addgroup -S php \
     && adduser -S -G php php \
     && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/php7/conf.d/* /etc/php7/php-fpm.d/*

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -9,6 +9,7 @@ RUN apk -U upgrade && apk add --no-cache \
     php7 \
     php7-fpm \
     tzdata \
+    && ln -s /usr/bin/php7 /usr/bin/php \
     && addgroup -S php \
     && adduser -S -G php php \
     && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/php7/conf.d/* /etc/php7/php-fpm.d/*

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -6,7 +6,7 @@ RUN apk -U upgrade && apk add --no-cache \
     curl \
     libc6-compat \
     nginx \
-    php7-cli \
+    php7 \
     php7-fpm \
     tzdata \
     && addgroup -S php \

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -7,7 +7,7 @@ RUN apk -U upgrade && apk add --no-cache \
     nginx \
     php7-fpm \
     tzdata \
-    && ln -s /usr/bin/php-fpm7 /usr/bin/php-fpm \
+    && ln -s /usr/sbin/php-fpm7 /usr/sbin/php-fpm \
     && addgroup -S php \
     && adduser -S -G php php \
     && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/php7/conf.d/* /etc/php7/php-fpm.d/*

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -4,11 +4,10 @@ MAINTAINER docker@stefan-van-essen.nl
 
 RUN apk -U upgrade && apk add --no-cache \
     curl \
-    libc6-compat \
     nginx \
-    php7 \
     php7-fpm \
     tzdata \
+    && ln -s /usr/bin/php-fpm7 /usr/bin/php-fpm \
     && addgroup -S php \
     && adduser -S -G php php \
     && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/php7/conf.d/* /etc/php7/php-fpm.d/*

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -2,9 +2,11 @@ FROM alpine:3.6
 
 MAINTAINER docker@stefan-van-essen.nl
 
-RUN apk -U upgrade && apk add \
+RUN apk -U upgrade && apk add --no-cache \
     curl \
+    libc6-compat \
     nginx \
+    php7-cli \
     php7-fpm \
     tzdata \
     && addgroup -S php \

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -6,7 +6,7 @@ RUN apk -U upgrade && apk add --no-cache \
     curl \
     libc6-compat \
     nginx \
-    php7-cli \
+    php7 \
     php7-fpm \
     tzdata \
     && addgroup -S php \

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,5 @@ clean:
 test:
 	if [ "$(TAGNAME)" = "UNDEF" ]; then echo "please provide a valid TAGNAME" && exit 1; fi
 	docker ps | grep existenz_webstack_instance | grep -q "(healthy)"
-	docker exec -t existenz_webstack_instance "php --version" | grep -q "PHP $(TAGNAME)"
+	docker exec -t existenz_webstack_instance php --version | grep -q "PHP $(TAGNAME)"
 	

--- a/Makefile
+++ b/Makefile
@@ -2,18 +2,16 @@
 
 # Variables
 PWD := $(dir $(MAKEPATH))
+S6TAG=v1.21.2.1
 PROJECTNAME=existenz/webstack
 TAGNAME=UNDEF
 
 build:
 	if [ "$(TAGNAME)" = "UNDEF" ]; then echo "please provide a valid TAGNAME" && exit 1; fi
+	test -d files/s6-overlay || mkdir -p files/s6-overlay
+	test -d files/s6-overlay || wget -P /tmp https://github.com/just-containers/s6-overlay/releases/download/$(S6TAG)/s6-overlay-amd64.tar.gz
+	test -d files/s6-overlay || gunzip -c /tmp/s6-overlay-amd64.tar.gz | tar -xf - -C files/s6-overlay
 	docker build -t $(PROJECTNAME):$(TAGNAME) -f Dockerfile-$(TAGNAME) --pull .
-
-install:
-	rm -rf files/s6-overlay
-	mkdir files/s6-overlay
-	wget -P /tmp https://github.com/just-containers/s6-overlay/releases/download/v1.19.1.1/s6-overlay-amd64.tar.gz
-	gunzip -c /tmp/s6-overlay-amd64.tar.gz | tar -xf - -C files/s6-overlay
 
 run:
 	if [ "$(TAGNAME)" = "UNDEF" ]; then echo "please provide a valid TAGNAME" && exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 .PHONY: install build run stop clean test
 
+# Variables
+PWD := $(dir $(MAKEPATH))
+PROJECTNAME=existenz/webstack
+TAGNAME=UNDEF
+
 build:
-	docker build -t existenz/webstack:5.6 -f Dockerfile-5.6 .
-	docker build -t existenz/webstack:7.0 -f Dockerfile-7.0 .
-	docker build -t existenz/webstack:7.1 -f Dockerfile-7.1 .
+	if [ "$(TAGNAME)" = "UNDEF" ]; then echo "please provide a valid TAGNAME" && exit 1; fi
+	docker build -t $(PROJECTNAME):$(TAGNAME) -f Dockerfile-$(TAGNAME) --pull .
 
 install:
 	rm -rf files/s6-overlay
@@ -12,25 +16,19 @@ install:
 	gunzip -c /tmp/s6-overlay-amd64.tar.gz | tar -xf - -C files/s6-overlay
 
 run:
-	docker run -d -p 8056:80 --name existenz_webstack_56 existenz/webstack:5.6
-	docker run -d -p 8070:80 --name existenz_webstack_70 existenz/webstack:7.0
-	docker run -d -p 8071:80 --name existenz_webstack_71 existenz/webstack:7.1
+	if [ "$(TAGNAME)" = "UNDEF" ]; then echo "please provide a valid TAGNAME" && exit 1; fi
+	docker run -d -p 8080:80 --name existenz_webstack_instance $(PROJECTNAME):$(TAGNAME)
 
 stop:
-	docker stop -t0 existenz_webstack_56
-	docker stop -t0 existenz_webstack_70
-	docker stop -t0 existenz_webstack_71
-	docker rm existenz_webstack_56
-	docker rm existenz_webstack_70
-	docker rm existenz_webstack_71
+	docker stop -t0 existenz_webstack_instance
+	docker rm existenz_webstack_instance
 
 clean:
+	if [ "$(TAGNAME)" = "UNDEF" ]; then echo "please provide a valid TAGNAME" && exit 1; fi
 	rm -rf files/s6-overlay
-	docker rmi existenz/webstack:5.6
-	docker rmi existenz/webstack:7.0
-	docker rmi existenz/webstack:7.1
+	docker rmi $(PROJECTNAME):$(TAGNAME)
 
 test:
-	docker ps | grep webstack_56 | grep -q "(healthy)"
-	docker ps | grep webstack_70 | grep -q "(healthy)"
-	docker ps | grep webstack_71 | grep -q "(healthy)"
+	docker ps | grep existenz_webstack_instance | grep -q "(healthy)"
+	docker exec -t existenz_webstack_instance php --version
+	

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,5 @@ clean:
 test:
 	if [ "$(TAGNAME)" = "UNDEF" ]; then echo "please provide a valid TAGNAME" && exit 1; fi
 	docker ps | grep existenz_webstack_instance | grep -q "(healthy)"
-	docker exec -t existenz_webstack_instance php --version | grep -q "PHP $(TAGNAME)"
+	docker exec -t existenz_webstack_instance php-fpm --version | grep -q "PHP $(TAGNAME)"
 	

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ TAGNAME=UNDEF
 
 build:
 	if [ "$(TAGNAME)" = "UNDEF" ]; then echo "please provide a valid TAGNAME" && exit 1; fi
-	test -d files/s6-overlay || mkdir -p files/s6-overlay
-	test -d files/s6-overlay || wget -P /tmp https://github.com/just-containers/s6-overlay/releases/download/$(S6TAG)/s6-overlay-amd64.tar.gz
-	test -d files/s6-overlay || gunzip -c /tmp/s6-overlay-amd64.tar.gz | tar -xf - -C files/s6-overlay
+	test -f files/s6-overlay/init || mkdir -p files/s6-overlay
+	test -f files/s6-overlay/init || wget -P /tmp https://github.com/just-containers/s6-overlay/releases/download/$(S6TAG)/s6-overlay-amd64.tar.gz
+	test -f files/s6-overlay/init || gunzip -c /tmp/s6-overlay-amd64.tar.gz | tar -xf - -C files/s6-overlay
 	docker build -t $(PROJECTNAME):$(TAGNAME) -f Dockerfile-$(TAGNAME) --pull .
 
 run:

--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ test:
 	if [ "$(TAGNAME)" = "UNDEF" ]; then echo "please provide a valid TAGNAME" && exit 1; fi
 	docker ps | grep existenz_webstack_instance | grep -q "(healthy)"
 	docker exec -t existenz_webstack_instance php-fpm --version | grep -q "PHP $(TAGNAME)"
-	
+	wget -q localhost:8080 -O- | grep -q "PHP Version $(TAGNAME)"

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ clean:
 	docker rmi $(PROJECTNAME):$(TAGNAME)
 
 test:
+	if [ "$(TAGNAME)" = "UNDEF" ]; then echo "please provide a valid TAGNAME" && exit 1; fi
 	docker ps | grep existenz_webstack_instance | grep -q "(healthy)"
-	docker exec -t existenz_webstack_instance php --version
+	docker exec -t existenz_webstack_instance "php --version" | grep -q "PHP $(TAGNAME)"
 	


### PR DESCRIPTION
Hi ya! :raising_hand_man: 

Currently, my 7.0 container was broken (https://forum.alpinelinux.org/forum/installation/php-7111-r0-community-edge-repo-does-not-start-properly%E2%80%A6)
I've added a test that prevents new images from being build whenever PHP CLI does not work.
In addition: I'm trying to add a matrix to prevent a broken 7.0 build to block PHP 5.6 updates

This is currently work in progress 