### PR TITLE
Export the http port

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -17,4 +17,6 @@ WORKDIR /www
 
 ENTRYPOINT ["/init"]
 
+EXPOSE 80
+
 HEALTHCHECK --interval=5s --timeout=5s CMD curl -f http://127.0.0.1/php-fpm-ping || exit 1

--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -18,4 +18,6 @@ WORKDIR /www
 
 ENTRYPOINT ["/init"]
 
+EXPOSE 80
+
 HEALTHCHECK --interval=5s --timeout=5s CMD curl -f http://127.0.0.1/php-fpm-ping || exit 1

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -18,4 +18,6 @@ WORKDIR /www
 
 ENTRYPOINT ["/init"]
 
+EXPOSE 80
+
 HEALTHCHECK --interval=5s --timeout=5s CMD curl -f http://127.0.0.1/php-fpm-ping || exit 1

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -18,4 +18,6 @@ WORKDIR /www
 
 ENTRYPOINT ["/init"]
 
+EXPOSE 80
+
 HEALTHCHECK --interval=5s --timeout=5s CMD curl -f http://127.0.0.1/php-fpm-ping || exit 1


### PR DESCRIPTION
> The `EXPOSE` instruction informs Docker that the container listens on the specified network ports at runtime. You can specify whether the port listens on TCP or UDP, and the default is TCP if the protocol is not specified.

It's nice to be explicit about this. I currently had to dig into the nginx config to find out what the correct port was (by default of course 80, but it could have been changed)

