### PR TITLE
Remove fpm access logs from stdout

### DIFF
--- a/files/php5/etc/php5/php-fpm.conf
+++ b/files/php5/etc/php5/php-fpm.conf
@@ -10,7 +10,6 @@ group = php
 
 listen = 127.0.0.1:9000
 
-access.log = /proc/self/fd/2
 catch_workers_output = yes
 
 ; Allow access to the environment variables that were passed on to Docker

--- a/files/php7/etc/php7/php-fpm.conf
+++ b/files/php7/etc/php7/php-fpm.conf
@@ -9,8 +9,6 @@ user = php
 group = php
 
 listen = 127.0.0.1:9000
-
-access.log = /proc/self/fd/2
 catch_workers_output = yes
 
 ; Allow access to the environment variables that were passed on to Docker


### PR DESCRIPTION
Heya :wave: 

This PR might be a bit opinionated: It removes the ambiguous access logs from the FPM pools. Why you ask? 

- These access logs clutter the stdout of my container with spam of healthcecks, something that is already [disabled in nginx](https://github.com/eXistenZNL/Docker-Webstack/blob/master/files/general/etc/nginx/nginx.conf#L50)
- Whenever a legitemate request is recieved the originating IP is always the local nginx and the requested resource almost always references to a `index.php` file when using modern frameworks. so yea ¯\_(ツ)_/¯



### A visual representation what this PR will address
Healthchecks in stdout:
![screenshot from 2018-08-03 19-39-35](https://user-images.githubusercontent.com/3368018/43657241-81034e7e-9755-11e8-9e70-5a87b70e5081.png)

Duplicate access logs on normal requests:
![screenshot from 2018-08-03 19-40-21](https://user-images.githubusercontent.com/3368018/43657252-88d89686-9755-11e8-91ce-7c52df6a5e2c.png)

After the changes:
![screenshot from 2018-08-03 19-42-31](https://user-images.githubusercontent.com/3368018/43657339-d26d9af8-9755-11e8-86f5-c7a48ddfbb6b.png)

In the example above you can also acknowledge that in the case of errors or exceptions. the output is still preserved in stdout. 


Thanks again for your project :tada: 