### PR TITLE
Bump s6 to v1.21.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Variables
 PWD := $(dir $(MAKEPATH))
-S6TAG=v1.21.2.1
+S6TAG=v1.21.4.0
 PROJECTNAME=existenz/webstack
 TAGNAME=UNDEF
 


### PR DESCRIPTION
Hey :wave: 

S6 has released some new versions. This should take care of bumping the default installed version in the WebStack.

Note: You'll have to flush your Travis caches for the changes to take effect :thinking: 