### PR TITLE
Add build for codecasts PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
     - env: TAG=7.1-codecasts
     - env: TAG=7.2
     - env: TAG=7.2-codecasts
+    - env: TAG=7.3-codecasts
+  allow_failures:
+    - env: TAG=7.3-codecasts
 
 services:
   - docker

--- a/Dockerfile-7.3-codecasts
+++ b/Dockerfile-7.3-codecasts
@@ -1,0 +1,27 @@
+FROM alpine:3.8
+
+MAINTAINER docker@stefan-van-essen.nl
+
+ADD https://php.codecasts.rocks/php-alpine.rsa.pub /etc/apk/keys/php-alpine.rsa.pub
+RUN apk --update add ca-certificates
+RUN echo "@php https://php.codecasts.rocks/v3.8/php-7.3" >> /etc/apk/repositories
+
+RUN apk -U upgrade && apk add --no-cache \
+    curl \
+    nginx \
+    php7-fpm@php \
+    tzdata \
+    && ln -s /usr/sbin/php-fpm7 /usr/sbin/php-fpm \
+    && addgroup -S php \
+    && adduser -S -G php php \
+    && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/php7/conf.d/* /etc/php7/php-fpm.d/*
+
+COPY files/s6-overlay files/general files/php7 /
+
+WORKDIR /www
+
+ENTRYPOINT ["/init"]
+
+EXPOSE 80
+
+HEALTHCHECK --interval=5s --timeout=5s CMD curl -f http://127.0.0.1/php-fpm-ping || exit 1


### PR DESCRIPTION
Heya :wave: 

I saw that Codecasts [documented their PHP 7.3 repo](https://github.com/codecasts/php-alpine) with a repository URL and the intended Alpine version.
Although the repo is still empty this PR will prepare your build for the expected release somewhere at the end of this year :). 

Have a nice day!
