### PR TITLE
Bump s6-overlay to v1.21.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Variables
 PWD := $(dir $(MAKEPATH))
-S6TAG=v1.21.4.0
+S6TAG=v1.21.7.0
 PROJECTNAME=existenz/webstack
 TAG=UNDEF
 PHP_VERSION=$(shell echo "$(TAG)" | sed -e 's/-codecasts//')


### PR DESCRIPTION
Heya :wave: 

Small update to keep the containers fresh :sunglasses: 

Make sure to flush the Travis build caches because the s6 extraction is kept in there :see_no_evil: 