### PR TITLE
Add the Alpine PHP 7.3 image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ matrix:
     - env: TAG=7.0
     - env: TAG=7.1
     - env: TAG=7.2
+    - env: TAG=7.3
     - env: TAG=7.2-codecasts
     - env: TAG=7.3-codecasts
 

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -1,0 +1,23 @@
+FROM alpine:3.10
+
+MAINTAINER docker@stefan-van-essen.nl
+
+RUN apk -U upgrade && apk add --no-cache \
+    curl \
+    nginx \
+    php7-fpm \
+    tzdata \
+    && ln -s /usr/sbin/php-fpm7 /usr/sbin/php-fpm \
+    && addgroup -S php \
+    && adduser -S -G php php \
+    && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/php7/conf.d/* /etc/php7/php-fpm.d/*
+
+COPY files/s6-overlay files/general files/php7 /
+
+WORKDIR /www
+
+ENTRYPOINT ["/init"]
+
+EXPOSE 80
+
+HEALTHCHECK --interval=5s --timeout=5s CMD curl -f http://127.0.0.1/php-fpm-ping || exit 1


### PR DESCRIPTION
### What

Adds the 'vanilla' PHP 7.3 container where the packages come from Alpine linux rather than the Codecasts repository