### PR TITLE
Build experimental stack with php8.0.0-rc1

### DIFF
--- a/Dockerfile-8.0-experimental
+++ b/Dockerfile-8.0-experimental
@@ -1,0 +1,30 @@
+FROM alpine:3.12
+
+LABEL maintainer="docker@stefan-van-essen.nl"
+
+ADD https://dl.bintray.com/php-alpine/key/php-alpine.rsa.pub /etc/apk/keys/php-alpine.rsa.pub
+RUN apk --update add ca-certificates
+RUN echo "https://dl.bintray.com/php-alpine/v3.12/php-8.0" >> /etc/apk/repositories
+
+RUN apk -U upgrade && apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
+    curl \
+    nginx \
+    php8-fpm \
+    tzdata \
+    && ln -s /usr/sbin/php-fpm8 /usr/sbin/php-fpm \
+    && addgroup -S php \
+    && adduser -S -G php php \
+    && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/php8/conf.d/* /etc/php8/php-fpm.d/*
+
+COPY files/s6-overlay files/general files/php8 /
+
+# Enable options supported by this version of PHP-FPM
+RUN sed '/decorate_workers_output/s/^; //g' /etc/php8/php-fpm.conf
+
+WORKDIR /www
+
+ENTRYPOINT ["/init"]
+
+EXPOSE 80
+
+HEALTHCHECK --interval=5s --timeout=5s CMD curl -f http://127.0.0.1/php-fpm-ping || exit 1

--- a/files/php8/etc/php8/php-fpm.conf
+++ b/files/php8/etc/php8/php-fpm.conf
@@ -1,0 +1,28 @@
+[global]
+pid = /var/run/php-fpm.pid
+error_log = /proc/self/fd/2
+log_level = notice
+daemonize  = no
+
+[www]
+user = php
+group = php
+
+listen = 127.0.0.1:9000
+catch_workers_output = yes
+; decorate_workers_output = no
+
+; Allow access to the environment variables that were passed on to Docker
+clear_env = no
+
+; Process manager
+pm = ondemand
+pm.max_children = 5
+pm.process_idle_timeout = 10s
+pm.max_requests = 500
+
+; Health check
+ping.path = /php-fpm-ping
+
+; Include other configuration files
+include=/etc/php8/php-fpm.d/*.conf

--- a/files/php8/etc/services.d/php-fpm7/run
+++ b/files/php8/etc/services.d/php-fpm7/run
@@ -1,0 +1,2 @@
+#!/usr/bin/with-contenv sh
+exec php-fpm8


### PR DESCRIPTION
_**Will my code run on PHP 8.0?**_
That is the big question this container could help answer. It uses the builds from codecasts, but I refrained from using codecasts in the tag for I think obvious reasons: the repositories and builds for PHP are "release candidate" at best, "WIP" at its worst. To allow a future stable `8.0-codecasts` tag, I have tagged this as `8.0-experimental`.
Optionally I could add a section to the readme stating that this tag will never receive any support and might very well be deleted in a few months.