### PR TITLE
Pin alpine to 3.11 due to bad signature errors

### DIFF
--- a/Dockerfile-7.4-codecasts
+++ b/Dockerfile-7.4-codecasts
@@ -1,10 +1,10 @@
-FROM alpine:3.12
+FROM alpine:3.11
 
 LABEL maintainer="docker@stefan-van-essen.nl"
 
 ADD https://dl.bintray.com/php-alpine/key/php-alpine.rsa.pub /etc/apk/keys/php-alpine.rsa.pub
 RUN apk --update add ca-certificates
-RUN echo "https://dl.bintray.com/php-alpine/v3.12/php-7.4" >> /etc/apk/repositories
+RUN echo "https://dl.bintray.com/php-alpine/v3.11/php-7.4" >> /etc/apk/repositories
 
 RUN apk -U upgrade && apk add --no-cache \
     curl \


### PR DESCRIPTION
This is to circumvent the issue mentioned in https://github.com/codecasts/php-alpine/issues/117