### PR TITLE
Require the configuration files for PHP 8

### DIFF
--- a/files/php8/etc/php8/php-fpm.conf
+++ b/files/php8/etc/php8/php-fpm.conf
@@ -25,4 +25,4 @@ pm.max_requests = 500
 ping.path = /php-fpm-ping
 
 ; Include other configuration files
-include=/etc/php7/php-fpm.d/*.conf
+include=/etc/php8/php-fpm.d/*.conf


### PR DESCRIPTION
Currently, the PHP8 configuration tries to load in other configuration files from a `php7` directory leading to the following warning: 

```
WARNING: Nothing matches the include pattern '/etc/php7/php-fpm.d/*.conf' from /etc/php8/php-fpm.conf at line 28.
```

The `php7` directory should be `php8`.