### PR TITLE
Add PHP symbolic link to the PHP8 container

### DIFF
--- a/Dockerfile-8.0
+++ b/Dockerfile-8.0
@@ -8,6 +8,7 @@ RUN apk -U upgrade && apk add --no-cache \
     php8-fpm \
     tzdata \
     && ln -s /usr/sbin/php-fpm8 /usr/sbin/php-fpm \
+    && ln -s /usr/bin/php8 /usr/bin/php \
     && addgroup -S php \
     && adduser -S -G php php \
     && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/php8/conf.d/* /etc/php8/php-fpm.d/*


### PR DESCRIPTION
Instead of having to use `php8` in your cli, you can now use `php`