### PR TITLE
Fix nginx config by removing http.d config

### DIFF
--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -10,7 +10,7 @@ RUN apk -U upgrade && apk add --no-cache \
     && ln -s /usr/sbin/php-fpm7 /usr/sbin/php-fpm \
     && addgroup -S php \
     && adduser -S -G php php \
-    && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/php7/conf.d/* /etc/php7/php-fpm.d/*
+    && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/nginx/http.d/* /etc/php7/conf.d/* /etc/php7/php-fpm.d/*
 
 COPY files/s6-overlay files/general files/php7 /
 

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -10,7 +10,7 @@ RUN apk -U upgrade && apk add --no-cache \
     && ln -s /usr/sbin/php-fpm7 /usr/sbin/php-fpm \
     && addgroup -S php \
     && adduser -S -G php php \
-    && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/nginx/http.d/* /etc/php7/conf.d/* /etc/php7/php-fpm.d/*
+    && rm -rf /var/cache/apk/* /etc/nginx/http.d/* /etc/php7/conf.d/* /etc/php7/php-fpm.d/*
 
 COPY files/s6-overlay files/general files/php7 /
 

--- a/Dockerfile-8.0
+++ b/Dockerfile-8.0
@@ -10,7 +10,7 @@ RUN apk -U upgrade && apk add --no-cache \
     && ln -s /usr/sbin/php-fpm8 /usr/sbin/php-fpm \
     && addgroup -S php \
     && adduser -S -G php php \
-    && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/php8/conf.d/* /etc/php8/php-fpm.d/*
+    && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/nginx/http.d/* /etc/php8/conf.d/* /etc/php8/php-fpm.d/*
 
 COPY files/s6-overlay files/general files/php8 /
 

--- a/Dockerfile-8.0
+++ b/Dockerfile-8.0
@@ -10,7 +10,7 @@ RUN apk -U upgrade && apk add --no-cache \
     && ln -s /usr/sbin/php-fpm8 /usr/sbin/php-fpm \
     && addgroup -S php \
     && adduser -S -G php php \
-    && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/nginx/http.d/* /etc/php8/conf.d/* /etc/php8/php-fpm.d/*
+    && rm -rf /var/cache/apk/* /etc/nginx/http.d/* /etc/php8/conf.d/* /etc/php8/php-fpm.d/*
 
 COPY files/s6-overlay files/general files/php8 /
 

--- a/Dockerfile-8.1
+++ b/Dockerfile-8.1
@@ -10,7 +10,7 @@ RUN apk -U upgrade && apk add --no-cache \
     && ln -s /usr/sbin/php-fpm81 /usr/sbin/php-fpm \
     && addgroup -S php \
     && adduser -S -G php php \
-    && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/nginx/http.d/* /etc/php81/conf.d/* /etc/php81/php-fpm.d/*
+    && rm -rf /var/cache/apk/* /etc/nginx/http.d/* /etc/php81/conf.d/* /etc/php81/php-fpm.d/*
 
 COPY files/s6-overlay files/general files/php81 /
 

--- a/Dockerfile-8.1
+++ b/Dockerfile-8.1
@@ -10,7 +10,7 @@ RUN apk -U upgrade && apk add --no-cache \
     && ln -s /usr/sbin/php-fpm81 /usr/sbin/php-fpm \
     && addgroup -S php \
     && adduser -S -G php php \
-    && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/php81/conf.d/* /etc/php81/php-fpm.d/*
+    && rm -rf /var/cache/apk/* /etc/nginx/conf.d/* /etc/nginx/http.d/* /etc/php81/conf.d/* /etc/php81/php-fpm.d/*
 
 COPY files/s6-overlay files/general files/php81 /
 

--- a/files/general/etc/nginx/nginx.conf
+++ b/files/general/etc/nginx/nginx.conf
@@ -62,4 +62,4 @@ http {
 }
 
 # Include other configuration files
-include /etc/nginx/conf.d/*.conf;
+include /etc/nginx/http.d/*.conf;


### PR DESCRIPTION
It seems like nginx now stores the config of the default.conf site in http.d instead of conf.d . 
Which causes nginx to shutdown with the following error
> 2022/07/24 18:48:00 [emerg] 920#920: a duplicate default server for 0.0.0.0:80 in /etc/nginx/http.d/default.conf:5

I observed this on the 8.1 docker image, But for good measure I added the same statements to all versions: Delete all the things. 