### PR TITLE
Add S6 service type (longrun)  for PHP and Nginx

### DIFF
--- a/files/general/etc/services.d/nginx/type
+++ b/files/general/etc/services.d/nginx/type
@@ -1,0 +1,1 @@
+longrun

--- a/files/php83/etc/services.d/php-fpm83/type
+++ b/files/php83/etc/services.d/php-fpm83/type
@@ -1,0 +1,1 @@
+longrun


### PR DESCRIPTION
This is a first step into moving to the new S6 v3 definitions