### PR TITLE
fix arm container startup error (fixes #58)

### DIFF
--- a/8.1.Dockerfile
+++ b/8.1.Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.18
 LABEL maintainer="docker@stefan-van-essen.nl"
 
 ARG S6_OVERLAY_VERSION=1.22.1.0
-ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 # Install webserver packages
 RUN apk -U upgrade && apk add --no-cache \
@@ -17,7 +17,7 @@ RUN apk -U upgrade && apk add --no-cache \
     && rm -rf /var/cache/apk/* /etc/nginx/http.d/* /etc/php81/conf.d/* /etc/php81/php-fpm.d/*
 
 # Install S6 overlay
-RUN case "${BUILDPLATFORM}" in \
+RUN case "${TARGETPLATFORM}" in \
         "linux/amd64") \
             wget -P /tmp https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz && \
             gunzip -c /tmp/s6-overlay-amd64.tar.gz | tar -xf - -C / \

--- a/8.2.Dockerfile
+++ b/8.2.Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.19
 LABEL maintainer="docker@stefan-van-essen.nl"
 
 ARG S6_OVERLAY_VERSION=1.22.1.0
-ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 # Install webserver packages
 RUN apk -U upgrade && apk add --no-cache \
@@ -17,7 +17,7 @@ RUN apk -U upgrade && apk add --no-cache \
     && rm -rf /var/cache/apk/* /etc/nginx/http.d/* /etc/php82/conf.d/* /etc/php82/php-fpm.d/*
 
 # Install S6 overlay
-RUN case "${BUILDPLATFORM}" in \
+RUN case "${TARGETPLATFORM}" in \
         "linux/amd64") \
             wget -P /tmp https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-amd64.tar.gz && \
             gunzip -c /tmp/s6-overlay-amd64.tar.gz | tar -xf - -C / \

--- a/8.3.Dockerfile
+++ b/8.3.Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.19
 LABEL maintainer="docker@stefan-van-essen.nl"
 
 ARG S6_OVERLAY_VERSION=3.1.6.2
-ARG BUILDPLATFORM
+ARG TARGETPLATFORM
 
 # Install webserver packages
 RUN apk -U upgrade && apk add --no-cache \
@@ -23,7 +23,7 @@ RUN wget -P /tmp https://github.com/just-containers/s6-overlay/releases/download
     tar -C / -Jxpf /tmp/s6-overlay-symlinks-noarch.tar.xz; \
     wget -P /tmp https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-symlinks-arch.tar.xz; \
     tar -C / -Jxpf /tmp/s6-overlay-symlinks-arch.tar.xz; \
-    case "${BUILDPLATFORM}" in \
+    case "${TARGETPLATFORM}" in \
         "linux/amd64") \
             wget -P /tmp https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-x86_64.tar.xz; \
             tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz; \


### PR DESCRIPTION
The Dockerfiles used `BUILDPLATFORM` to choose the s6-overlay arch, but it needs to be the `TARGETPLATFORM` to work properly.

Tested with M1 mac and ubuntu 24.04 (arm - ampere).

fixes #58 