### PR TITLE
Update the Alpine version for PHP 8.1

### DIFF
--- a/8.1.Dockerfile
+++ b/8.1.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.19
 
 LABEL maintainer="docker@stefan-van-essen.nl"
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See the table below to see what versions are currently available:
 
 | Image tag | Based on          | PHP Packages from                                                                               | S6-Overlay |
 |-----------|-------------------|-------------------------------------------------------------------------------------------------|------------|
-| 8.1       | Alpine Linux 3.18 | [Alpine Linux repo](https://pkgs.alpinelinux.org/packages?name=php81*&branch=v3.18&arch=x86_64) | Version 1  |
+| 8.1       | Alpine Linux 3.19 | [Alpine Linux repo](https://pkgs.alpinelinux.org/packages?name=php81*&branch=v3.19&arch=x86_64) | Version 1  |
 | 8.2       | Alpine Linux 3.19 | [Alpine Linux repo](https://pkgs.alpinelinux.org/packages?name=php82*&branch=v3.19&arch=x86_64) | Version 1  |
 | 8.3       | Alpine Linux 3.19 | [Alpine Linux repo](https://pkgs.alpinelinux.org/packages?name=php83*&branch=v3.19&arch=x86_64) | Version 3  |
 | 8.4       | Alpine Linux 3.21 | [Alpine Linux repo](https://pkgs.alpinelinux.org/packages?name=php84*&branch=v3.21&arch=x86_64) | Version 3  |


### PR DESCRIPTION
## What

Alpine 3.18 will be EOL [May 9th 2025](https://endoflife.date/alpine) however PHP 8.1 is still maintained until [December 31st 2025](https://endoflife.date/php).

To prevent running on an EOL version of Alpine, update Alpine from 3.18 to 3.19.
This version of Alpine still has PHP 8.1 available.

Make sure to merge this simultaneously with https://github.com/eXistenZNL/Docker-Builder/pull/46.