### PR TITLE
Bump PHP 8.2, 8.3, 8.4 and 8.5-edge containers to Alpine 3.22

### DIFF
--- a/8.2.Dockerfile
+++ b/8.2.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.22
 
 LABEL maintainer="docker@stefan-van-essen.nl"
 

--- a/8.3.Dockerfile
+++ b/8.3.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.22
 
 LABEL maintainer="docker@stefan-van-essen.nl"
 

--- a/8.4.Dockerfile
+++ b/8.4.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.22
 
 LABEL maintainer="docker@stefan-van-essen.nl"
 

--- a/8.5-edge.Dockerfile
+++ b/8.5-edge.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21
+FROM alpine:3.22
 
 LABEL maintainer="docker@stefan-van-essen.nl"
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ See the table below to see what versions are currently available:
 | Image tag | Based on          | PHP Packages from                                                                               | S6-Overlay |
 |-----------|-------------------|-------------------------------------------------------------------------------------------------|------------|
 | 8.1       | Alpine Linux 3.19 | [Alpine Linux repo](https://pkgs.alpinelinux.org/packages?name=php81*&branch=v3.19&arch=x86_64) | Version 1  |
-| 8.2       | Alpine Linux 3.19 | [Alpine Linux repo](https://pkgs.alpinelinux.org/packages?name=php82*&branch=v3.19&arch=x86_64) | Version 1  |
-| 8.3       | Alpine Linux 3.19 | [Alpine Linux repo](https://pkgs.alpinelinux.org/packages?name=php83*&branch=v3.19&arch=x86_64) | Version 3  |
-| 8.4       | Alpine Linux 3.21 | [Alpine Linux repo](https://pkgs.alpinelinux.org/packages?name=php84*&branch=v3.21&arch=x86_64) | Version 3  |
+| 8.2       | Alpine Linux 3.22 | [Alpine Linux repo](https://pkgs.alpinelinux.org/packages?name=php82*&branch=v3.22&arch=x86_64) | Version 1  |
+| 8.3       | Alpine Linux 3.22 | [Alpine Linux repo](https://pkgs.alpinelinux.org/packages?name=php83*&branch=v3.22&arch=x86_64) | Version 3  |
+| 8.4       | Alpine Linux 3.22 | [Alpine Linux repo](https://pkgs.alpinelinux.org/packages?name=php84*&branch=v3.22&arch=x86_64) | Version 3  |
 | 8.5-edge  | Alpine Linux Edge | [Alpine Linux repo](https://pkgs.alpinelinux.org/packages?name=php85*&branch=edge&arch=x86_64)  | Version 3  |
 
 ### Overriding or extending the configuration


### PR DESCRIPTION
## What

This is a round of Alpine updates triggered by the fact that Alpine 3.19 is almost EOL. Whilst I was here, I took the liberty to bump every container to the latest Alpine version that supports the required version of PHP.

Sadly PHP 8.1 is only available in Alpine 3.19 which is going EOL Nov 1st, but PHP 8.1 is almost EOL as well anyway (Dec 31st) so we'll live.

## Note

Goes together with https://github.com/eXistenZNL/Docker-Builder/pull/49